### PR TITLE
case-fix

### DIFF
--- a/mlMainWindow.cpp
+++ b/mlMainWindow.cpp
@@ -673,7 +673,7 @@ void mlMainWindow::OnFileNew()
 	Layout->addLayout(FormLayout);
 
 	QLineEdit* NameWidget = new QLineEdit();
-	NameWidget->setValidator(new QRegularExpressionValidator(QRegularExpression("[a-z0-9_]*"), this));
+	NameWidget->setValidator(new QRegularExpressionValidator(QRegularExpression("[a-zA-Z0-9_]*"), this));
 	FormLayout->addRow("Name:", NameWidget);
 
 	QComboBox* TemplateWidget = new QComboBox();
@@ -712,7 +712,7 @@ void mlMainWindow::OnFileNew()
 		return;
 	}
 
-	QByteArray MapName = NameWidget->text().toLatin1();
+	QByteArray MapName = NameWidget->text().toLatin1().toLower();
 	QString Output;
 
 	QString Template = Templates[TemplateWidget->currentIndex()];


### PR DESCRIPTION
I was a bit shocked to see this wasn't a thing by default, however this allows people to enter their map name, it kinda helps if you're copying something but it has an upper-case letter so I've just changed it a bit so it lets you do that then forces it back to lower before it is ready to be used. I know it's not a game breaking issue but hey.