### PR TITLE
Convert button added

### DIFF
--- a/mlMainWindow.cpp
+++ b/mlMainWindow.cpp
@@ -27,16 +27,16 @@ const int AppId = 311210;
 const char* gLanguages[] = { "english", "french", "italian", "spanish", "german", "portuguese", "russian", "polish", "japanese", "traditionalchinese", "simplifiedchinese", "englisharabic" };
 const char* gTags[] = { "Animation", "Audio", "Character", "Map", "Mod", "Mode", "Model", "Multiplayer", "Scorestreak", "Skin", "Specialist", "Texture", "UI", "Vehicle", "Visual Effect", "Weapon", "WIP", "Zombies" };
 dvar_s gDvars[] = {
-					{"ai_disableSpawn", "Disable AI from spawning", DVAR_VALUE_BOOL},
-					{"developer", "Run developer mode", DVAR_VALUE_INT, 0, 2},
-					{"g_password", "Password for your server", DVAR_VALUE_STRING},
-					{"logfile", "Console log information written to current fs_game", DVAR_VALUE_INT, 0, 2},
-					{"scr_mod_enable_devblock", "Developer blocks are executed in mods ", DVAR_VALUE_BOOL},
-					{"connect", "Connect to a specific server", DVAR_VALUE_STRING, NULL, NULL, true},
-					{"set_gametype", "Set a gametype to load with map", DVAR_VALUE_STRING, NULL, NULL, true},
-					{"splitscreen", "Enable splitscreen", DVAR_VALUE_BOOL},
-					{"splitscreen_playerCount", "Allocate the number of instances for splitscreen", DVAR_VALUE_INT, 0, 2}
-				 };
+	{"ai_disableSpawn", "Disable AI from spawning", DVAR_VALUE_BOOL},
+	{"developer", "Run developer mode", DVAR_VALUE_INT, 0, 2},
+	{"g_password", "Password for your server", DVAR_VALUE_STRING},
+	{"logfile", "Console log information written to current fs_game", DVAR_VALUE_INT, 0, 2},
+	{"scr_mod_enable_devblock", "Developer blocks are executed in mods ", DVAR_VALUE_BOOL},
+	{"connect", "Connect to a specific server", DVAR_VALUE_STRING, NULL, NULL, true},
+	{"set_gametype", "Set a gametype to load with map", DVAR_VALUE_STRING, NULL, NULL, true},
+	{"splitscreen", "Enable splitscreen", DVAR_VALUE_BOOL},
+	{"splitscreen_playerCount", "Allocate the number of instances for splitscreen", DVAR_VALUE_INT, 0, 2}
+};
 enum mlItemType
 {
 	ML_ITEM_UNKNOWN,
@@ -254,7 +254,7 @@ mlMainWindow::mlMainWindow()
 
 	setWindowIcon(QIcon(":/resources/ModLauncher.png"));
 	setWindowTitle("Black Ops III Mod Tools Launcher");
-	
+
 	resize(1024, 768);
 
 	CreateActions();
@@ -324,6 +324,10 @@ mlMainWindow::mlMainWindow()
 	mDvarsButton = new QPushButton("Dvars");
 	connect(mDvarsButton, SIGNAL(clicked()), this, SLOT(OnEditDvars()));
 	ActionsLayout->addWidget(mDvarsButton);
+
+	mConvertButton = new QPushButton("Converter");
+	connect(mConvertButton,SIGNAL(clicked()),this,SLOT(OnConvertClicked()));
+	ActionsLayout->addWidget(mConvertButton);
 
 	mIgnoreErrorsWidget = new QCheckBox("Ignore Errors");
 	ActionsLayout->addWidget(mIgnoreErrorsWidget);
@@ -395,7 +399,7 @@ void mlMainWindow::CreateActions()
 
 void mlMainWindow::CreateMenu()
 {
-	QMenuBar* MenuBar = new QMenuBar(this);
+	MenuBar = new QMenuBar(this);
 
 	QMenu* FileMenu = new QMenu("&File", MenuBar);
 	FileMenu->addAction(mActionFileNew);
@@ -423,7 +427,7 @@ void mlMainWindow::CreateMenu()
 
 void mlMainWindow::CreateToolBar()
 {
-	QToolBar* ToolBar = new QToolBar("Standard", this);
+	ToolBar = new QToolBar("Standard", this);
 	ToolBar->setObjectName(QStringLiteral("StandardToolBar"));
 
 	ToolBar->addAction(mActionFileNew);
@@ -459,7 +463,7 @@ void mlMainWindow::InitExport2BinGUI()
 
 	mExport2BinOverwriteWidget = new QCheckBox("&Overwrite Existing Files", widget);
 	gridLayout->addWidget(mExport2BinOverwriteWidget, 1, 0);
-	
+
 	QSettings Settings;
 	mExport2BinOverwriteWidget->setChecked(Settings.value("Export2Bin_OverwriteFiles", true).toBool());
 
@@ -518,6 +522,12 @@ void mlMainWindow::UpdateDB()
 
 void mlMainWindow::StartBuildThread(const QList<QPair<QString, QStringList>>& Commands)
 {
+	if(mIsConverting)
+	{
+		mOutputWidget->appendPlainText("Aborted Conversion!");
+		mIsConverting = false;
+	}
+
 	mBuildButton->setText("Cancel");
 	mOutputWidget->clear();
 
@@ -1311,26 +1321,26 @@ void mlMainWindow::UpdateWorkshopItem()
 
 	SteamUGC()->SetItemTags(UpdateHandle, &Tags);
 
-	 SteamAPICall_t SteamAPICall = SteamUGC()->SubmitItemUpdate(UpdateHandle, "");
-	 mSteamCallResultUpdateItem.Set(SteamAPICall, this, &mlMainWindow::OnUpdateItemResult);
+	SteamAPICall_t SteamAPICall = SteamUGC()->SubmitItemUpdate(UpdateHandle, "");
+	mSteamCallResultUpdateItem.Set(SteamAPICall, this, &mlMainWindow::OnUpdateItemResult);
 
-	 QProgressDialog Dialog(this);
-	 Dialog.setLabelText(QString("Uploading workshop item '%1'...").arg(QString::number(mFileId)));
-	 Dialog.setCancelButton(NULL);
-	 Dialog.setWindowModality(Qt::WindowModal);
-	 Dialog.show();
+	QProgressDialog Dialog(this);
+	Dialog.setLabelText(QString("Uploading workshop item '%1'...").arg(QString::number(mFileId)));
+	Dialog.setCancelButton(NULL);
+	Dialog.setWindowModality(Qt::WindowModal);
+	Dialog.show();
 
-	 for (;;)
-	 {
-		 uint64 Processed, Total;
-		 if (SteamUGC()->GetItemUpdateProgress(SteamAPICall, &Processed, &Total) == k_EItemUpdateStatusInvalid)
-			 break;
+	for (;;)
+	{
+		uint64 Processed, Total;
+		if (SteamUGC()->GetItemUpdateProgress(SteamAPICall, &Processed, &Total) == k_EItemUpdateStatusInvalid)
+			break;
 
-		 Dialog.setMaximum(Total);
-		 Dialog.setValue(Processed);
-		 QApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
-		 Sleep(100);
-	 }
+		Dialog.setMaximum(Total);
+		Dialog.setValue(Processed);
+		QApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
+		Sleep(100);
+	}
 }
 
 void mlMainWindow::OnCreateItemResult(CreateItemResult_t* CreateItemResult, bool IOFailure)
@@ -1380,7 +1390,7 @@ void mlMainWindow::OnOpenZoneFile()
 	QList<QTreeWidgetItem*> ItemList = mFileListWidget->selectedItems();
 	if (ItemList.isEmpty())
 		return;
-	
+
 	QTreeWidgetItem* Item = ItemList[0];
 
 	if (Item->data(0, Qt::UserRole).toInt() == ML_ITEM_MAP)
@@ -1583,7 +1593,7 @@ void Export2BinGroupBox::dropEvent(QDropEvent* event)
 		{
 			pathList.append(urlList.at(i).toLocalFile());
 		}
-		
+
 		QProcess* Process = new QProcess();
 		connect(Process, SIGNAL(finished(int)), Process, SLOT(deleteLater()));
 
@@ -1591,7 +1601,7 @@ void Export2BinGroupBox::dropEvent(QDropEvent* event)
 
 		QString outputDir = parentWindow->mExport2BinTargetDirWidget->text();
 		parentWindow->StartConvertThread(pathList, outputDir, allowOverwrite);
-		
+
 		event->acceptProposedAction();
 	}
 }
@@ -1599,4 +1609,27 @@ void Export2BinGroupBox::dropEvent(QDropEvent* event)
 void Export2BinGroupBox::dragLeaveEvent(QDragLeaveEvent* event)
 {
 	event->accept();
+}
+
+void mlMainWindow::OnConvertClicked()
+{
+	if(mIsConverting)
+	{
+		mOutputWidget->appendPlainText("Aborted Conversion!");
+		mIsConverting = false;
+	}
+	else
+	{
+		auto Reply = QMessageBox::information(this,"Converter Warning!","This will take a long time, are you sure you wish to continue?",QMessageBox::Yes | QMessageBox::No);
+		if(Reply == QMessageBox::Yes)
+		{
+			mOutputWidget->appendPlainText("Starting Convertion!");
+			mIsConverting = true;
+			//Do Things Carl
+			QList<QPair<QString, QStringList>> Commands;
+			Commands.append(QPair<QString, QStringList>(QString("%1/bin/linker_modtools.exe").arg(mToolsPath), QStringList() << "-language" << "english" << "-convertall" << "-verbose"));
+
+			StartBuildThread(Commands);
+		}
+	}
 }

--- a/mlMainWindow.cpp
+++ b/mlMainWindow.cpp
@@ -1613,23 +1613,15 @@ void Export2BinGroupBox::dragLeaveEvent(QDragLeaveEvent* event)
 
 void mlMainWindow::OnConvertClicked()
 {
-	if(mIsConverting)
-	{
-		mOutputWidget->appendPlainText("Aborted Conversion!");
-		mIsConverting = false;
-	}
-	else
-	{
 		auto Reply = QMessageBox::information(this,"Converter Warning!","This will take a long time, are you sure you wish to continue?",QMessageBox::Yes | QMessageBox::No);
 		if(Reply == QMessageBox::Yes)
 		{
 			mOutputWidget->appendPlainText("Starting Convertion!");
 			mIsConverting = true;
-			//Do Things Carl
+
 			QList<QPair<QString, QStringList>> Commands;
 			Commands.append(QPair<QString, QStringList>(QString("%1/bin/linker_modtools.exe").arg(mToolsPath), QStringList() << "-language" << "english" << "-convertall" << "-verbose"));
 
 			StartBuildThread(Commands);
 		}
-	}
 }

--- a/mlMainWindow.cpp
+++ b/mlMainWindow.cpp
@@ -1613,6 +1613,8 @@ void Export2BinGroupBox::dragLeaveEvent(QDragLeaveEvent* event)
 
 void mlMainWindow::OnConvertClicked()
 {
+	if(!mIsConverting)
+	{
 		auto Reply = QMessageBox::information(this,"Converter Warning!","This will take a long time, are you sure you wish to continue?",QMessageBox::Yes | QMessageBox::No);
 		if(Reply == QMessageBox::Yes)
 		{
@@ -1624,4 +1626,8 @@ void mlMainWindow::OnConvertClicked()
 
 			StartBuildThread(Commands);
 		}
+	}
+	else
+	{
+		QMessageBox::warning(this,"Already Converting","Conversion is already in progress!",QMessageBox::Ok); //Cheeky DLC5 Comment Here.
 }

--- a/mlMainWindow.cpp
+++ b/mlMainWindow.cpp
@@ -1630,4 +1630,5 @@ void mlMainWindow::OnConvertClicked()
 	else
 	{
 		QMessageBox::warning(this,"Already Converting","Conversion is already in progress!",QMessageBox::Ok); //Cheeky DLC5 Comment Here.
+	}
 }

--- a/mlMainWindow.h
+++ b/mlMainWindow.h
@@ -117,6 +117,7 @@ protected slots:
 	void BuildFinished();
 	void ContextMenuRequested();
 	void SteamUpdate();
+	void OnConvertClicked();
 
 protected:
 	void closeEvent(QCloseEvent* Event);
@@ -150,6 +151,7 @@ protected:
 
 	QPushButton* mBuildButton;
 	QPushButton* mDvarsButton;
+	QPushButton* mConvertButton;
 	QCheckBox* mCompileEnabledWidget;
 	QComboBox* mCompileModeWidget;
 	QCheckBox* mLightEnabledWidget;
@@ -167,6 +169,8 @@ protected:
 	QLineEdit* mExport2BinTargetDirWidget;
 
 	bool mTreyarchTheme;
+	bool mIsConverting;
+
 	QString mBuildLanguage;
 
 	QStringList mShippedMapList;
@@ -185,6 +189,9 @@ protected:
 	QString mToolsPath;
 
 	QStringList mRunDvars;
+
+	QMenuBar* MenuBar;
+	QToolBar* ToolBar;
 };
 
 class Export2BinGroupBox : public QGroupBox


### PR DESCRIPTION
Apparently I understand the code a bit.

This one is just giving the launcher an **OPTIONAL** button that lets users convert all the assets at once.
Just bringing back the vibes from the good ol' launcher days from World at War.


I moved:
QMenuBar* MenuBar;
QToolBar* ToolBar;

to mlMainWindow.h because I was going to setup disabling of all the controls while it's converting, but I figured against that as it would probably cause more issues with newer users who would end up being like "hurrr why can't I do this?!?!?!", but if it should be like that I can easily submit my beta commits.